### PR TITLE
Comparison of `encoding/gob` vs `encoding/json` for serialization of SDK datamodel

### DIFF
--- a/internal/pkg/data/bench_test.go
+++ b/internal/pkg/data/bench_test.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package data
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var (
+	traceID = [16]byte{0x1}
+
+	spanID1 = [8]byte{0x1}
+	spanID2 = [8]byte{0x2}
+
+	now      = time.Now()
+	nowPlus1 = now.Add(1 * time.Second)
+
+	spanA = &Span{
+		TraceId:           traceID,
+		SpanId:            spanID2,
+		ParentSpanId:      spanID1,
+		Flags:             1,
+		Name:              "span-a",
+		StartTimeUnixNano: uint64(now.UnixNano()),
+		EndTimeUnixNano:   uint64(nowPlus1.UnixNano()),
+		Status: &Status{
+			Message: "test status",
+			Code:    Status_STATUS_CODE_OK,
+		},
+	}
+
+	spanB = &Span{}
+
+	scopeSpans = &ScopeSpans{
+		Scope: &InstrumentationScope{
+			Name:    "TestTracer",
+			Version: "v0.1.0",
+		},
+		SchemaUrl: "http://go.opentelemetry.io/test",
+		Spans:     []*Span{spanA, spanB},
+	}
+)
+
+func BenchmarkGOBMarshalUnmarshal(b *testing.B) {
+	// TODO:
+	gob.Register(AnyValue_StringValue{})
+	gob.Register(AnyValue_BoolValue{})
+
+	var out ScopeSpans
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		var inBuf bytes.Buffer
+		enc := gob.NewEncoder(&inBuf)
+		err := enc.Encode(scopeSpans)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		payload := inBuf.Bytes()
+
+		dec := gob.NewDecoder(bytes.NewReader(payload))
+		err = dec.Decode(&out)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	_ = out
+}
+
+func BenchmarkJSONMarshalUnmarshal(b *testing.B) {
+	var out ScopeSpans
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		var inBuf bytes.Buffer
+		enc := json.NewEncoder(&inBuf)
+		err := enc.Encode(scopeSpans)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		payload := inBuf.Bytes()
+
+		dec := json.NewDecoder(bytes.NewReader(payload))
+		err = dec.Decode(&out)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	_ = out
+}

--- a/internal/pkg/data/common.go
+++ b/internal/pkg/data/common.go
@@ -1,0 +1,384 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package data
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+var (
+	ErrInvalidLengthCommon        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowCommon          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupCommon = fmt.Errorf("proto: unexpected end of group")
+)
+
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+type AnyValue struct {
+	// The value is one of the listed fields. It is valid for all values to be unspecified
+	// in which case this AnyValue is considered to be "empty".
+	//
+	// Types that are assignable to Value:
+	//	*AnyValue_StringValue
+	//	*AnyValue_BoolValue
+	//	*AnyValue_IntValue
+	//	*AnyValue_DoubleValue
+	//	*AnyValue_ArrayValue
+	//	*AnyValue_KvlistValue
+	//	*AnyValue_BytesValue
+	Value isAnyValue_Value
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *AnyValue) UnmarshalJSON(data []byte) error {
+	var raw struct{ Value map[string]any }
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	for _, val := range raw.Value {
+		switch v := val.(type) {
+		case string:
+			m.Value = &AnyValue_StringValue{
+				StringValue: v,
+			}
+
+		case bool:
+			m.Value = &AnyValue_BoolValue{
+				BoolValue: v,
+			}
+		case int64:
+			m.Value = &AnyValue_IntValue{
+				IntValue: v,
+			}
+		case float64:
+			m.Value = &AnyValue_DoubleValue{
+				DoubleValue: v,
+			}
+		case []byte:
+			decoded, err := base64.StdEncoding.DecodeString(string(v))
+			if err != nil {
+				return fmt.Errorf("base64 decode: %w", err)
+			}
+			m.Value = &AnyValue_BytesValue{
+				BytesValue: decoded,
+			}
+		/*
+			 TODO:
+						case "arrayValue", "array_value":
+							m.Value = &AnyValue_ArrayValue{
+								ArrayValue: readArray(iter),
+							}
+						case "kvlistValue", "kvlist_value":
+							m.Value = &AnyValue_KvlistValue{
+								KvlistValue: readKvlistValue(iter),
+							}
+		*/
+		default:
+			return fmt.Errorf("unsupported value type: %T", val)
+		}
+	}
+	return nil
+}
+
+func (m *AnyValue) GetValue() isAnyValue_Value {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (x *AnyValue) GetStringValue() string {
+	if x, ok := x.GetValue().(*AnyValue_StringValue); ok {
+		return x.StringValue
+	}
+	return ""
+}
+
+func (x *AnyValue) GetBoolValue() bool {
+	if x, ok := x.GetValue().(*AnyValue_BoolValue); ok {
+		return x.BoolValue
+	}
+	return false
+}
+
+func (x *AnyValue) GetIntValue() int64 {
+	if x, ok := x.GetValue().(*AnyValue_IntValue); ok {
+		return x.IntValue
+	}
+	return 0
+}
+
+func (x *AnyValue) GetDoubleValue() float64 {
+	if x, ok := x.GetValue().(*AnyValue_DoubleValue); ok {
+		return x.DoubleValue
+	}
+	return 0
+}
+
+func (x *AnyValue) GetArrayValue() *ArrayValue {
+	if x, ok := x.GetValue().(*AnyValue_ArrayValue); ok {
+		return x.ArrayValue
+	}
+	return nil
+}
+
+func (x *AnyValue) GetKvlistValue() *KeyValueList {
+	if x, ok := x.GetValue().(*AnyValue_KvlistValue); ok {
+		return x.KvlistValue
+	}
+	return nil
+}
+
+func (x *AnyValue) GetBytesValue() []byte {
+	if x, ok := x.GetValue().(*AnyValue_BytesValue); ok {
+		return x.BytesValue
+	}
+	return nil
+}
+
+type isAnyValue_Value interface {
+	isAnyValue_Value()
+}
+
+type AnyValue_StringValue struct {
+	StringValue string `json:"stringValue"`
+}
+
+type AnyValue_BoolValue struct {
+	BoolValue bool `json:"boolValue"`
+}
+
+type AnyValue_IntValue struct {
+	IntValue int64 `json:"intValue"`
+}
+
+type AnyValue_DoubleValue struct {
+	DoubleValue float64 `json:"doubleValue"`
+}
+
+type AnyValue_ArrayValue struct {
+	ArrayValue *ArrayValue `json:"arrayValue"`
+}
+
+type AnyValue_KvlistValue struct {
+	KvlistValue *KeyValueList `json:"kvlistValue"`
+}
+
+type AnyValue_BytesValue struct {
+	BytesValue []byte `json:"bytesValue"`
+}
+
+func (*AnyValue_StringValue) isAnyValue_Value() {}
+
+func (*AnyValue_BoolValue) isAnyValue_Value() {}
+
+func (*AnyValue_IntValue) isAnyValue_Value() {}
+
+func (*AnyValue_DoubleValue) isAnyValue_Value() {}
+
+func (*AnyValue_ArrayValue) isAnyValue_Value() {}
+
+func (*AnyValue_KvlistValue) isAnyValue_Value() {}
+
+func (*AnyValue_BytesValue) isAnyValue_Value() {}
+
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
+type ArrayValue struct {
+	// Array of values. The array may be empty (contain 0 elements).
+	Values []*AnyValue `json:"values,omitempty"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (x *ArrayValue) GetValues() []*AnyValue {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+type KeyValueList struct {
+	// A collection of key/value pairs of key-value pairs. The list may be empty (may
+	// contain 0 elements).
+	// The keys MUST be unique (it is not allowed to have more than one
+	// value with the same key).
+	Values []*KeyValue `json:"values,omitempty"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (x *KeyValueList) GetValues() []*KeyValue {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+// KeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+type KeyValue struct {
+	Key   string    `json:"key,omitempty"`
+	Value *AnyValue `json:"value,omitempty"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (x *KeyValue) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *KeyValue) GetValue() *AnyValue {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version.
+type InstrumentationScope struct {
+	// An empty instrumentation scope name means the name is unknown.
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+	// Additional attributes that describe the scope. [Optional].
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	Attributes             []*KeyValue `json:"attributes,omitempty"`
+	DroppedAttributesCount uint32      `json:"dropped_attributes_count,omitempty"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (x *InstrumentationScope) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *InstrumentationScope) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *InstrumentationScope) GetAttributes() []*KeyValue {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+func (x *InstrumentationScope) GetDroppedAttributesCount() uint32 {
+	if x != nil {
+		return x.DroppedAttributesCount
+	}
+	return 0
+}
+
+func skipCommon(data []byte) (n int, err error) {
+	l := len(data)
+	index := 0
+	depth := 0
+	for index < l {
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return 0, ErrIntOverflowCommon
+			}
+			if index >= l {
+				return 0, io.ErrUnexpectedEOF
+			}
+			b := data[index]
+			index++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		wireType := int(wire & 0x7)
+		switch wireType {
+		case 0:
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return 0, ErrIntOverflowCommon
+				}
+				if index >= l {
+					return 0, io.ErrUnexpectedEOF
+				}
+				index++
+				if data[index-1] < 0x80 {
+					break
+				}
+			}
+		case 1:
+			index += 8
+		case 2:
+			var length int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return 0, ErrIntOverflowCommon
+				}
+				if index >= l {
+					return 0, io.ErrUnexpectedEOF
+				}
+				b := data[index]
+				index++
+				length |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if length < 0 {
+				return 0, ErrInvalidLengthCommon
+			}
+			index += length
+		case 3:
+			depth++
+		case 4:
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupCommon
+			}
+			depth--
+		case 5:
+			index += 4
+		default:
+			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
+		}
+		if index < 0 {
+			return 0, ErrInvalidLengthCommon
+		}
+		if depth == 0 {
+			return index, nil
+		}
+	}
+	return 0, io.ErrUnexpectedEOF
+}

--- a/internal/pkg/data/trace.go
+++ b/internal/pkg/data/trace.go
@@ -1,0 +1,561 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package data
+
+// SpanFlags represents constants used to interpret the
+// Span.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+//	(span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK)
+//
+// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+//
+// Note that Span flags were introduced in version 1.1 of the
+// OpenTelemetry protocol.  Older Span producers do not set this
+// field, consequently consumers should not rely on the absence of a
+// particular flag bit to indicate the presence of a particular feature.
+type SpanFlags int32
+
+const (
+	// The zero value for the enum. Should not be used for comparisons.
+	// Instead use bitwise "and" with the appropriate mask as shown above.
+	SpanFlags_SPAN_FLAGS_DO_NOT_USE SpanFlags = 0
+	// Bits 0-7 are used for trace flags.
+	SpanFlags_SPAN_FLAGS_TRACE_FLAGS_MASK SpanFlags = 255
+	// Bits 8 and 9 are used to indicate that the parent span or link span is remote.
+	// Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known.
+	// Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.
+	SpanFlags_SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK SpanFlags = 256
+	SpanFlags_SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK     SpanFlags = 512
+)
+
+// Enum value maps for SpanFlags.
+var (
+	SpanFlags_name = map[int32]string{
+		0:   "SPAN_FLAGS_DO_NOT_USE",
+		255: "SPAN_FLAGS_TRACE_FLAGS_MASK",
+		256: "SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK",
+		512: "SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK",
+	}
+	SpanFlags_value = map[string]int32{
+		"SPAN_FLAGS_DO_NOT_USE":                 0,
+		"SPAN_FLAGS_TRACE_FLAGS_MASK":           255,
+		"SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK": 256,
+		"SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK":     512,
+	}
+)
+
+func (x SpanFlags) Enum() *SpanFlags {
+	p := new(SpanFlags)
+	*p = x
+	return p
+}
+
+// SpanKind is the type of span. Can be used to specify additional relationships between spans
+// in addition to a parent/child relationship.
+type Span_SpanKind int32
+
+const (
+	// Unspecified. Do NOT use as default.
+	// Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
+	Span_SPAN_KIND_UNSPECIFIED Span_SpanKind = 0
+	// Indicates that the span represents an internal operation within an application,
+	// as opposed to an operation happening at the boundaries. Default value.
+	Span_SPAN_KIND_INTERNAL Span_SpanKind = 1
+	// Indicates that the span covers server-side handling of an RPC or other
+	// remote network request.
+	Span_SPAN_KIND_SERVER Span_SpanKind = 2
+	// Indicates that the span describes a request to some remote service.
+	Span_SPAN_KIND_CLIENT Span_SpanKind = 3
+	// Indicates that the span describes a producer sending a message to a broker.
+	// Unlike CLIENT and SERVER, there is often no direct critical path latency relationship
+	// between producer and consumer spans. A PRODUCER span ends when the message was accepted
+	// by the broker while the logical processing of the message might span a much longer time.
+	Span_SPAN_KIND_PRODUCER Span_SpanKind = 4
+	// Indicates that the span describes consumer receiving a message from a broker.
+	// Like the PRODUCER kind, there is often no direct critical path latency relationship
+	// between producer and consumer spans.
+	Span_SPAN_KIND_CONSUMER Span_SpanKind = 5
+)
+
+// Enum value maps for Span_SpanKind.
+var (
+	Span_SpanKind_name = map[int32]string{
+		0: "SPAN_KIND_UNSPECIFIED",
+		1: "SPAN_KIND_INTERNAL",
+		2: "SPAN_KIND_SERVER",
+		3: "SPAN_KIND_CLIENT",
+		4: "SPAN_KIND_PRODUCER",
+		5: "SPAN_KIND_CONSUMER",
+	}
+	Span_SpanKind_value = map[string]int32{
+		"SPAN_KIND_UNSPECIFIED": 0,
+		"SPAN_KIND_INTERNAL":    1,
+		"SPAN_KIND_SERVER":      2,
+		"SPAN_KIND_CLIENT":      3,
+		"SPAN_KIND_PRODUCER":    4,
+		"SPAN_KIND_CONSUMER":    5,
+	}
+)
+
+func (x Span_SpanKind) Enum() *Span_SpanKind {
+	p := new(Span_SpanKind)
+	*p = x
+	return p
+}
+
+// For the semantics of status codes see
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
+type Status_StatusCode int32
+
+const (
+	// The default status.
+	Status_STATUS_CODE_UNSET Status_StatusCode = 0
+	// The Span has been validated by an Application developer or Operator to
+	// have completed successfully.
+	Status_STATUS_CODE_OK Status_StatusCode = 1
+	// The Span contains an error.
+	Status_STATUS_CODE_ERROR Status_StatusCode = 2
+)
+
+// Enum value maps for Status_StatusCode.
+var (
+	Status_StatusCode_name = map[int32]string{
+		0: "STATUS_CODE_UNSET",
+		1: "STATUS_CODE_OK",
+		2: "STATUS_CODE_ERROR",
+	}
+	Status_StatusCode_value = map[string]int32{
+		"STATUS_CODE_UNSET": 0,
+		"STATUS_CODE_OK":    1,
+		"STATUS_CODE_ERROR": 2,
+	}
+)
+
+func (x Status_StatusCode) Enum() *Status_StatusCode {
+	p := new(Status_StatusCode)
+	*p = x
+	return p
+}
+
+// A collection of Spans produced by an InstrumentationScope.
+type ScopeSpans struct {
+	// The instrumentation scope information for the spans in this message.
+	// Semantically when InstrumentationScope isn't set, it is equivalent with
+	// an empty instrumentation scope name (unknown).
+	Scope *InstrumentationScope `json:"scope,omitempty"`
+	// A list of Spans that originate from an instrumentation scope.
+	Spans []*Span `json:"spans,omitempty"`
+	// The Schema URL, if known. This is the identifier of the Schema that the span data
+	// is recorded in. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to all spans and span events in the "spans" field.
+	SchemaUrl string `json:"schema_url,omitempty"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (x *ScopeSpans) GetScope() *InstrumentationScope {
+	if x != nil {
+		return x.Scope
+	}
+	return nil
+}
+
+func (x *ScopeSpans) GetSpans() []*Span {
+	if x != nil {
+		return x.Spans
+	}
+	return nil
+}
+
+func (x *ScopeSpans) GetSchemaUrl() string {
+	if x != nil {
+		return x.SchemaUrl
+	}
+	return ""
+}
+
+// A Span represents a single operation performed by a single component of the system.
+//
+// The next available field id is 17.
+type Span struct {
+	// A unique identifier for a trace. All spans from the same trace share
+	// the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+	// of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+	// is zero-length and thus is also invalid).
+	//
+	// This field is required.
+	TraceId [16]byte `json:"trace_id,omitempty"`
+	// A unique identifier for a span within a trace, assigned when the span
+	// is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+	// other than 8 bytes is considered invalid (empty string in OTLP/JSON
+	// is zero-length and thus is also invalid).
+	//
+	// This field is required.
+	SpanId [8]byte `json:"span_id,omitempty"`
+	// trace_state conveys information about request position in multiple distributed tracing graphs.
+	// It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+	// See also https://github.com/w3c/distributed-tracing for more details about this field.
+	TraceState string `json:"trace_state,omitempty"`
+	// The `span_id` of this span's parent span. If this is a root span, then this
+	// field must be empty. The ID is an 8-byte array.
+	ParentSpanId [8]byte `json:"parent_span_id,omitempty"`
+	// Flags, a bit field.
+	//
+	// Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+	// Context specification. To read the 8-bit W3C trace flag, use
+	// `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+	//
+	// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+	//
+	// Bits 8 and 9 represent the 3 states of whether a span's parent
+	// is remote. The states are (unknown, is not remote, is remote).
+	// To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+	// To read whether the span is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
+	//
+	// When creating span messages, if the message is logically forwarded from another source
+	// with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
+	// be copied as-is. If creating from a source that does not have an equivalent flags field
+	// (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST
+	// be set to zero.
+	// Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
+	//
+	// [Optional].
+	Flags uint32 `json:"flags,omitempty"`
+	// A description of the span's operation.
+	//
+	// For example, the name can be a qualified method name or a file name
+	// and a line number where the operation is called. A best practice is to use
+	// the same display name at the same call point in an application.
+	// This makes it easier to correlate spans in different traces.
+	//
+	// This field is semantically required to be set to non-empty string.
+	// Empty value is equivalent to an unknown span name.
+	//
+	// This field is required.
+	Name string `json:"name,omitempty"`
+	// Distinguishes between spans generated in a particular context. For example,
+	// two spans with the same name may be distinguished using `CLIENT` (caller)
+	// and `SERVER` (callee) to identify queueing latency associated with the span.
+	Kind Span_SpanKind `json:"kind,omitempty"`
+	// start_time_unix_nano is the start time of the span. On the client side, this is the time
+	// kept by the local machine where the span execution starts. On the server side, this
+	// is the time when the server's application handler starts running.
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+	//
+	// This field is semantically required and it is expected that end_time >= start_time.
+	StartTimeUnixNano uint64 `json:"start_time_unix_nano,omitempty"`
+	// end_time_unix_nano is the end time of the span. On the client side, this is the time
+	// kept by the local machine where the span execution ends. On the server side, this
+	// is the time when the server application handler stops running.
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+	//
+	// This field is semantically required and it is expected that end_time >= start_time.
+	EndTimeUnixNano uint64 `json:"end_time_unix_nano,omitempty"`
+	// attributes is a collection of key/value pairs. Note, global attributes
+	// like server name can be set using the resource API. Examples of attributes:
+	//
+	//     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+	//     "/http/server_latency": 300
+	//     "example.com/myattribute": true
+	//     "example.com/score": 10.239
+	//
+	// The OpenTelemetry API specification further restricts the allowed value types:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	Attributes []*KeyValue `json:"attributes,omitempty"`
+	// dropped_attributes_count is the number of attributes that were discarded. Attributes
+	// can be discarded because their keys are too long or because there are too many
+	// attributes. If this value is 0, then no attributes were dropped.
+	DroppedAttributesCount uint32 `json:"dropped_attributes_count,omitempty"`
+	// events is a collection of Event items.
+	Events []*Span_Event `json:"events,omitempty"`
+	// dropped_events_count is the number of dropped events. If the value is 0, then no
+	// events were dropped.
+	DroppedEventsCount uint32 `json:"dropped_events_count,omitempty"`
+	// links is a collection of Links, which are references from this span to a span
+	// in the same or different trace.
+	Links []*Span_Link `json:"links,omitempty"`
+	// dropped_links_count is the number of dropped links after the maximum size was
+	// enforced. If this value is 0, then no links were dropped.
+	DroppedLinksCount uint32 `json:"dropped_links_count,omitempty"`
+	// An optional final status for this span. Semantically when Status isn't set, it means
+	// span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
+	Status *Status `json:"status,omitempty"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (x *Span) GetTraceId() []byte {
+	if x != nil {
+		return x.TraceId[:]
+	}
+	return nil
+}
+
+func (x *Span) GetSpanId() []byte {
+	if x != nil {
+		return x.SpanId[:]
+	}
+	return nil
+}
+
+func (x *Span) GetTraceState() string {
+	if x != nil {
+		return x.TraceState
+	}
+	return ""
+}
+
+func (x *Span) GetParentSpanId() []byte {
+	if x != nil {
+		return x.ParentSpanId[:]
+	}
+	return nil
+}
+
+func (x *Span) GetFlags() uint32 {
+	if x != nil {
+		return x.Flags
+	}
+	return 0
+}
+
+func (x *Span) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Span) GetKind() Span_SpanKind {
+	if x != nil {
+		return x.Kind
+	}
+	return Span_SPAN_KIND_UNSPECIFIED
+}
+
+func (x *Span) GetStartTimeUnixNano() uint64 {
+	if x != nil {
+		return x.StartTimeUnixNano
+	}
+	return 0
+}
+
+func (x *Span) GetEndTimeUnixNano() uint64 {
+	if x != nil {
+		return x.EndTimeUnixNano
+	}
+	return 0
+}
+
+func (x *Span) GetAttributes() []*KeyValue {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+func (x *Span) GetDroppedAttributesCount() uint32 {
+	if x != nil {
+		return x.DroppedAttributesCount
+	}
+	return 0
+}
+
+func (x *Span) GetEvents() []*Span_Event {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
+func (x *Span) GetDroppedEventsCount() uint32 {
+	if x != nil {
+		return x.DroppedEventsCount
+	}
+	return 0
+}
+
+func (x *Span) GetLinks() []*Span_Link {
+	if x != nil {
+		return x.Links
+	}
+	return nil
+}
+
+func (x *Span) GetDroppedLinksCount() uint32 {
+	if x != nil {
+		return x.DroppedLinksCount
+	}
+	return 0
+}
+
+func (x *Span) GetStatus() *Status {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+// The Status type defines a logical error model that is suitable for different
+// programming environments, including REST APIs and RPC APIs.
+type Status struct {
+	// A developer-facing human readable error message.
+	Message string `json:"message,omitempty"`
+	// The status code.
+	Code Status_StatusCode `json:"code,omitempty"`
+}
+
+func (x *Status) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *Status) GetCode() Status_StatusCode {
+	if x != nil {
+		return x.Code
+	}
+	return Status_STATUS_CODE_UNSET
+}
+
+// Event is a time-stamped annotation of the span, consisting of user-supplied
+// text description and key-value pairs.
+type Span_Event struct {
+	// time_unix_nano is the time the event occurred.
+	TimeUnixNano uint64 `json:"time_unix_nano,omitempty"`
+	// name of the event.
+	// This field is semantically required to be set to non-empty string.
+	Name string `json:"name,omitempty"`
+	// attributes is a collection of attribute key/value pairs on the event.
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	Attributes []*KeyValue `json:"attributes,omitempty"`
+	// dropped_attributes_count is the number of dropped attributes. If the value is 0,
+	// then no attributes were dropped.
+	DroppedAttributesCount uint32 `json:"dropped_attributes_count,omitempty"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (x *Span_Event) GetTimeUnixNano() uint64 {
+	if x != nil {
+		return x.TimeUnixNano
+	}
+	return 0
+}
+
+func (x *Span_Event) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Span_Event) GetAttributes() []*KeyValue {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+func (x *Span_Event) GetDroppedAttributesCount() uint32 {
+	if x != nil {
+		return x.DroppedAttributesCount
+	}
+	return 0
+}
+
+// A pointer from the current span to another span in the same trace or in a
+// different trace. For example, this can be used in batching operations,
+// where a single batch handler processes multiple requests from different
+// traces or when the handler receives a request from a different project.
+type Span_Link struct {
+	// A unique identifier of a trace that this linked span is part of. The ID is a
+	// 16-byte array.
+	TraceId []byte `json:"trace_id,omitempty"`
+	// A unique identifier for the linked span. The ID is an 8-byte array.
+	SpanId []byte `json:"span_id,omitempty"`
+	// The trace_state associated with the link.
+	TraceState string `json:"trace_state,omitempty"`
+	// attributes is a collection of attribute key/value pairs on the link.
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	Attributes []*KeyValue `json:"attributes,omitempty"`
+	// dropped_attributes_count is the number of dropped attributes. If the value is 0,
+	// then no attributes were dropped.
+	DroppedAttributesCount uint32 `json:"dropped_attributes_count,omitempty"`
+	// Flags, a bit field.
+	//
+	// Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+	// Context specification. To read the 8-bit W3C trace flag, use
+	// `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+	//
+	// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+	//
+	// Bits 8 and 9 represent the 3 states of whether the link is remote.
+	// The states are (unknown, is not remote, is remote).
+	// To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+	// To read whether the link is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
+	//
+	// Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
+	// When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.
+	//
+	// [Optional].
+	Flags uint32 `json:"flags,omitempty"`
+}
+
+func (x *Span_Link) GetTraceId() []byte {
+	if x != nil {
+		return x.TraceId
+	}
+	return nil
+}
+
+func (x *Span_Link) GetSpanId() []byte {
+	if x != nil {
+		return x.SpanId
+	}
+	return nil
+}
+
+func (x *Span_Link) GetTraceState() string {
+	if x != nil {
+		return x.TraceState
+	}
+	return ""
+}
+
+func (x *Span_Link) GetAttributes() []*KeyValue {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
+func (x *Span_Link) GetDroppedAttributesCount() uint32 {
+	if x != nil {
+		return x.DroppedAttributesCount
+	}
+	return 0
+}
+
+func (x *Span_Link) GetFlags() uint32 {
+	if x != nil {
+		return x.Flags
+	}
+	return 0
+}


### PR DESCRIPTION
```terminal
$ go test -run="^$" -bench=.
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/auto/internal/pkg/data
cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
BenchmarkGOBMarshalUnmarshal-8    	    4609	    266378 ns/op	   35710 B/op	     778 allocs/op
BenchmarkJSONMarshalUnmarshal-8   	   41809	     26202 ns/op	    1793 B/op	      20 allocs/op
PASS
```